### PR TITLE
Reflow static content on terminal size change

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"code-excerpt": "^4.0.0",
 		"es-toolkit": "^1.22.0",
 		"indent-string": "^5.0.0",
-		"is-in-ci": "^1.0.0",
 		"patch-console": "^2.0.0",
 		"react-reconciler": "^0.29.0",
 		"scheduler": "^0.23.0",

--- a/src/components/Static.tsx
+++ b/src/components/Static.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState, useLayoutEffect, type ReactNode} from 'react';
+import React, {useMemo, type ReactNode} from 'react';
 import {type Styles} from '../styles.js';
 
 export type Props<T> = {
@@ -32,20 +32,12 @@ export type Props<T> = {
  * a list of completed tests. [Gatsby](https://github.com/gatsbyjs/gatsby) uses it
  * to display a list of generated pages, while still displaying a live progress bar.
  */
+
 export default function Static<T>(props: Props<T>) {
 	const {items, children: render, style: customStyle} = props;
-	const [index, setIndex] = useState(0);
 
-	const itemsToRender: T[] = useMemo(() => {
-		return items.slice(index);
-	}, [items, index]);
-
-	useLayoutEffect(() => {
-		setIndex(items.length);
-	}, [items.length]);
-
-	const children = itemsToRender.map((item, itemIndex) => {
-		return render(item, index + itemIndex);
+	const children = items.map((item, itemIndex) => {
+		return render(item, itemIndex);
 	});
 
 	const style: Styles = useMemo(

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -56,7 +56,10 @@ export type Props = {
 	readonly children?: ReactNode;
 
         /**
-          * Whether this text is semantically a prompt.
+         * This property tells Ink to mark any line containing
+         * this text as a prompt using terminal control codes.  Many terminal
+         * emulators have UI affordances for navigating between prompts and
+         * segmenting the scrollback on prompt boundaries.
          */
 	readonly osc133prompt?: boolean;
 };

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -3,6 +3,7 @@ import chalk, {type ForegroundColorName} from 'chalk';
 import {type LiteralUnion} from 'type-fest';
 import colorize from '../colorize.js';
 import {type Styles} from '../styles.js';
+import {type OutputTransformerResult} from '../render-node-to-output.js';
 
 export type Props = {
 	/**
@@ -53,6 +54,11 @@ export type Props = {
 	readonly wrap?: Styles['textWrap'];
 
 	readonly children?: ReactNode;
+
+        /**
+          * Whether this text is semantically a prompt.
+         */
+	readonly osc133prompt?: boolean;
 };
 
 /**
@@ -68,13 +74,14 @@ export default function Text({
 	strikethrough = false,
 	inverse = false,
 	wrap = 'wrap',
+	osc133prompt = false,
 	children,
 }: Props) {
 	if (children === undefined || children === null) {
 		return null;
 	}
 
-	const transform = (children: string): string => {
+	const transform = (children: string): OutputTransformerResult => {
 		if (dimColor) {
 			children = chalk.dim(children);
 		}
@@ -107,7 +114,10 @@ export default function Text({
 			children = chalk.inverse(children);
 		}
 
-		return children;
+		return {
+			line: children,
+			isPrompt: osc133prompt,
+		};
 	};
 
 	return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+// Terminal dimension defaults
+export const DEFAULT_TERMINAL_WIDTH = 80;
+export const DEFAULT_TERMINAL_HEIGHT = 24;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -22,12 +22,19 @@ declare namespace Ink {
 		style?: Except<Styles, 'textWrap'>;
 	};
 
+        export type OutputTransformerResult = {
+                line: string,
+                isPrompt?: boolean,
+                [x: string]: any,
+        } | string;
+
 	type Text = {
 		children?: ReactNode;
 		key?: Key;
 		style?: Styles;
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
-		internal_transform?: (children: string, index: number) => string;
+		internal_transform?: (children: string, index: number) =>
+			OutputTransformerResult;
 	};
 }

--- a/src/hooks/use-terminal-dimensions.ts
+++ b/src/hooks/use-terminal-dimensions.ts
@@ -1,0 +1,36 @@
+import { useState, useLayoutEffect } from 'react';
+import useStdout from './use-stdout.js';
+import { DEFAULT_TERMINAL_WIDTH, DEFAULT_TERMINAL_HEIGHT } from '../constants.js';
+
+/**
+ * Hook that returns and tracks terminal dimensions.
+ * The component will re-render when terminal dimensions change.
+ */
+const useTerminalDimensions = () => {
+  const { stdout } = useStdout();
+  const [dimensions, setDimensions] = useState({
+    columns: stdout.columns || DEFAULT_TERMINAL_WIDTH,
+    rows: stdout.rows || DEFAULT_TERMINAL_HEIGHT
+  });
+
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      setDimensions({
+        columns: stdout.columns || DEFAULT_TERMINAL_WIDTH,
+        rows: stdout.rows || DEFAULT_TERMINAL_HEIGHT
+      });
+    };
+
+    handleResize();
+
+    stdout.on('resize', handleResize);
+
+    return () => {
+      stdout.off('resize', handleResize);
+    };
+  }, [stdout]);
+
+  return dimensions;
+};
+
+export default useTerminalDimensions;

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -104,7 +104,7 @@ export default class Ink {
 		this.fullStaticOutput = '';
 
 		// Emit initial OSC 133 prompt start escape
-		if (!isInCi) {
+		if (!isInCi && options.osc133) {
 			options.stdout.write(oscPromptStartRefreshLine);
 		}
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -2,7 +2,6 @@ import process from 'node:process';
 import React, {type ReactNode} from 'react';
 import {throttle} from 'es-toolkit/compat';
 import ansiEscapes from 'ansi-escapes';
-import isInCi from 'is-in-ci';
 import autoBind from 'auto-bind';
 import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
@@ -14,6 +13,8 @@ import logUpdate, {type LogUpdate} from './log-update.js';
 import instances from './instances.js';
 import App from './components/App.js';
 import Yoga from 'yoga-wasm-web/auto';
+
+const isInCi = Boolean(process.env["CI"]);
 
 const noop = () => {};
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -15,6 +15,7 @@ import App from './components/App.js';
 import Yoga from 'yoga-wasm-web/auto';
 
 const isInCi = Boolean(process.env["CI"]);
+const isTTY = process.stdout.isTTY;
 
 const noop = () => {};
 
@@ -201,12 +202,12 @@ export default class Ink {
 		// Ask terminal emulators not to redraw the framebuffer
 		// while we're in the middle of a atomic update.  Avoids flicker.
 		try {
-			if (!isInCi) {
+			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateStart);
 			}
 			this.onRenderInternal(didResize);
 		} finally {
-			if (!isInCi) {
+			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateEnd);
 			}
 		}
@@ -231,7 +232,7 @@ export default class Ink {
 		let startOscCommand: string;
 		let endOscCommand: string;
 
-		if (isInCi || !this.options.osc133) {
+		if (isInCi || !isTTY || !this.options.osc133) {
 			startOscPrompt = '';
 			endOscPrompt = '';
 			startOscCommand = '';
@@ -244,7 +245,7 @@ export default class Ink {
 		}
 
 		// Colors make everything more fun.
-		if (this.options.debug) {
+		if (this.options.debug && isTTY) {
 			// Dark blue is for prompt mode.  Exiting prompt
 			// mode resets the background color.
 			startOscPrompt += '\x1b[48;5;17m';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -48,6 +48,7 @@ export type Options = {
 	patchConsole: boolean;
 	waitUntilExit?: () => Promise<void>;
 	onFlicker?: () => unknown;
+	osc133?: boolean;
 };
 
 const stripPrefixIfPresent = (prefix: string, s: string): string => {
@@ -198,10 +199,22 @@ export default class Ink {
 		// support the more flexible oscPromptStart; the Output class has
 		// logic for making sure that we send oscPromptStartRefreshLine only
 		// at the start of the line, where it won't move cursor.
-		let startOscPrompt = oscPromptStartRefreshLine;
-		let endOscPrompt = oscPromptEnd;
-		let startOscCommand = oscCommandStart;
-		let endOscCommand = oscCommandEnd;
+		let startOscPrompt: string;
+		let endOscPrompt: string;
+		let startOscCommand: string;
+		let endOscCommand: string;
+
+		if (isInCi || !this.options.osc133) {
+			startOscPrompt = '';
+			endOscPrompt = '';
+			startOscCommand = '';
+			endOscCommand = '';
+		} else {
+			startOscPrompt = oscPromptStartRefreshLine;
+			endOscPrompt = oscPromptEnd;
+			startOscCommand = oscCommandStart;
+			endOscCommand = oscCommandEnd;
+		}
 
 		// Colors make everything more fun.
 		if (this.options.debug) {
@@ -214,14 +227,6 @@ export default class Ink {
 			// color on exit.
 			startOscCommand += '\x1b[48;5;52m';
 			endOscCommand = '\x1b[49m' + endOscCommand;
-		}
-
-		// ... CI is not for fun.
-		if (isInCi) {
-			startOscPrompt = '';
-			endOscCommand = '';
-			startOscCommand = '';
-			endOscCommand = '';
 		}
 
 		// For render() output purposes, we assume we're in command mode,

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -17,6 +17,17 @@ import Yoga from 'yoga-wasm-web/auto';
 
 const noop = () => {};
 
+// OSC133 terminal escapes for marking parts of the output
+// as prompt or command output, as if we were a shell.
+//
+// We need both prompt and command markers: terminal UI affordances
+// use both.  For example, kitty has a command
+// (bound to control-shift-g by default) that displays the last output
+// chunkin a pager.
+//
+// See https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+// and https://iterm2.com/documentation-escape-codes.html
+
 const oscPromptStartRefreshLine = '\x1b]133;A\x07';
 const oscPromptEnd = '\x1b]133;B\x07';
 const oscCommandStart = '\x1b]133;C\x07';
@@ -193,6 +204,14 @@ export default class Ink {
 			// color on exit.
 			startOscCommand += '\x1b[48;5;52m';
 			endOscCommand = '\x1b[49m' + endOscCommand;
+		}
+
+		// ... CI is not for fun.
+		if (isInCi) {
+			startOscPrompt = '';
+			endOscCommand = '';
+			startOscCommand = '';
+			endOscCommand = '';
 		}
 
 		// For render() output purposes, we assume we're in command mode,

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -17,6 +17,11 @@ import Yoga from 'yoga-wasm-web/auto';
 
 const noop = () => {};
 
+const oscPromptStartRefreshLine = '\x1b]133;A\x07';
+const oscPromptEnd = '\x1b]133;B\x07';
+const oscCommandStart = '\x1b]133;C\x07';
+const oscCommandEnd = '\x1b]133;D\x07';
+
 export type Options = {
 	stdout: NodeJS.WriteStream;
 	stdin: NodeJS.ReadStream;
@@ -26,6 +31,12 @@ export type Options = {
 	patchConsole: boolean;
 	waitUntilExit?: () => Promise<void>;
 	onFlicker?: () => unknown;
+};
+
+const stripPrefixIfPresent = (prefix: string, s: string): string => {
+	return s.startsWith(prefix)
+	? s.substring(prefix.length)
+	: s;
 };
 
 export default class Ink {
@@ -69,6 +80,11 @@ export default class Ink {
 		// This variable is used only in debug mode to store full static output
 		// so that it's rerendered every time, not just new static parts, like in non-debug mode
 		this.fullStaticOutput = '';
+
+		// Emit initial OSC 133 prompt start escape
+		if (!isInCi) {
+			options.stdout.write(oscPromptStartRefreshLine);
+		}
 
 		// Unmount when process exits
 		this.unsubscribeExit = signalExit(this.unmount, {alwaysLast: false});
@@ -157,14 +173,50 @@ export default class Ink {
 			return;
 		}
 
-		const {output, outputHeight, staticOutput} = render(this.rootNode);
+		// Need to use oscPromptStartRefreshLine because iTerm2 doesn't
+		// support the more flexible oscPromptStart; the Output class has
+		// logic for making sure that we send oscPromptStartRefreshLine only
+		// at the start of the line, where it won't move cursor.
+		let startOscPrompt = oscPromptStartRefreshLine;
+		let endOscPrompt = oscPromptEnd;
+		let startOscCommand = oscCommandStart;
+		let endOscCommand = oscCommandEnd;
+
+		// Colors make everything more fun.
+		if (this.options.debug) {
+			// Dark blue is for prompt mode.  Exiting prompt
+			// mode resets the background color.
+			startOscPrompt += '\x1b[48;5;17m';
+			endOscPrompt = '\x1b[49m' + endOscPrompt;
+
+			// Dark red for command mode.  Likewise, reset
+			// color on exit.
+			startOscCommand += '\x1b[48;5;52m';
+			endOscCommand = '\x1b[49m' + endOscCommand;
+		}
+
+		// For render() output purposes, we assume we're in command mode,
+		// so whenever we enter prompt mode we leave command mode, and whenever
+		// we leave prompt mode, we re-enter command mode.
+		const {output, outputHeight, staticOutput} = render(
+			this.rootNode,
+			endOscCommand + startOscPrompt,
+			endOscPrompt + startOscCommand);
 
 		// If <Static> output isn't empty, it means new children have been added to it
 		const hasStaticOutput = staticOutput && staticOutput !== '\n';
 
+		// For static output, we assume we're in prompt mode to start.
+		const wrappedStaticOutput = hasStaticOutput
+				   ? (endOscPrompt +
+				      startOscCommand +
+				      staticOutput /* assume ends with \n */ +
+				      startOscPrompt)
+				   : staticOutput;
+
 		if (this.options.debug) {
 			if (hasStaticOutput) {
-				this.fullStaticOutput += staticOutput;
+				this.fullStaticOutput += wrappedStaticOutput;
 			}
 
 			this.options.stdout.write(this.fullStaticOutput + output);
@@ -173,7 +225,7 @@ export default class Ink {
 
 		if (isInCi) {
 			if (hasStaticOutput) {
-				this.options.stdout.write(staticOutput);
+				this.options.stdout.write(wrappedStaticOutput);
 			}
 
 			this.lastOutput = output;
@@ -182,8 +234,21 @@ export default class Ink {
 		}
 
 		if (hasStaticOutput) {
-			this.fullStaticOutput += staticOutput;
+			this.fullStaticOutput += wrappedStaticOutput;
 		}
+
+		const writeFullStaticOutput = () => {
+			// fullStaticOutput has embedded prompt-end prompt-start OSC133
+			// sequences; it expects to be printed in the in-prompt state.
+			// Strip any leading prompt-stop off the string when we print
+			// it so that it's appropriate to print in our non-prompt-start
+			// context.  We add an extra newline to match what logOutput does.
+			this.options.stdout.write(
+				endOscPrompt +
+				ansiEscapes.clearTerminal +
+				stripPrefixIfPresent(endOscPrompt, this.fullStaticOutput) +
+				output + '\n');
+		};
 
 		if (
 			outputHeight >= this.options.stdout.rows ||
@@ -192,10 +257,7 @@ export default class Ink {
 			if (this.options.onFlicker) {
 				this.options.onFlicker();
 			}
-			// We add an extra newline to match what logOutput does
-			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
-			);
+			writeFullStaticOutput();
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;
 			// Account for the extra newline
@@ -204,9 +266,7 @@ export default class Ink {
 		}
 
 		if (didResize) {
-			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
-			);
+			writeFullStaticOutput();
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;
 			this.log.updateLineCount(output + '\n');
@@ -216,7 +276,10 @@ export default class Ink {
 		// To ensure static output is cleanly rendered before main output, clear main output first
 		if (hasStaticOutput) {
 			this.log.clear();
-			this.options.stdout.write(staticOutput);
+			// wrappedStaticOutput sends prompt-end, command-out-start,
+			// the incremental static output, and then prompt-start.
+			// Pre- and post-condition: in OSC133 prompt mode
+			this.options.stdout.write(wrappedStaticOutput);
 			this.throttledLog(output);
 		}
 
@@ -309,8 +372,18 @@ export default class Ink {
 		// only render last frame of non-static output
 		if (isInCi) {
 			this.options.stdout.write(this.lastOutput + '\n');
-		} else if (!this.options.debug) {
-			this.log.done();
+		} else {
+			if (!this.options.debug) {
+				this.log.done();
+			}
+
+			// End the prompt at unmount.  Reset background color
+			// if we were debugging.
+			if (this.options.debug) {
+				this.options.stdout.write('\x1b[49m');
+			}
+
+			this.options.stdout.write(oscPromptEnd);
 		}
 
 		this.isUnmounted = true;

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import React, {type ReactNode} from 'react';
 import {throttle} from 'es-toolkit/compat';
-import ansiEscapes from 'ansi-escapes';
 import autoBind from 'auto-bind';
 import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
@@ -13,6 +12,7 @@ import logUpdate, {type LogUpdate} from './log-update.js';
 import instances from './instances.js';
 import App from './components/App.js';
 import Yoga from 'yoga-wasm-web/auto';
+import { DEFAULT_TERMINAL_WIDTH } from './constants.js';
 
 const isInCi = Boolean(process.env["CI"]);
 const isTTY = process.stdout.isTTY;
@@ -64,12 +64,6 @@ export type Options = {
 	osc133?: boolean;
 };
 
-const stripPrefixIfPresent = (prefix: string, s: string): string => {
-	return s.startsWith(prefix)
-	? s.substring(prefix.length)
-	: s;
-};
-
 function stripOsc133(s: string): string {
 	return s.replace(anyOsc133Regex, '');
 }
@@ -81,12 +75,8 @@ export default class Ink {
 	// Ignore last render after unmounting a tree to prevent empty output before exit
 	private isUnmounted: boolean;
 	private lastOutput: string;
-	private lastOutputHeight: number;
 	private readonly container: FiberRoot;
 	private rootNode: dom.DOMElement | null = null;
-	// This variable is used only in debug mode to store full static output
-	// so that it's rerendered every time, not just new static parts, like in non-debug mode
-	private fullStaticOutput: string;
 	private exitPromise?: Promise<void>;
 	private restoreConsole?: () => void;
 	private readonly unsubscribeResize?: () => void;
@@ -108,16 +98,11 @@ export default class Ink {
 		// Store last output to only rerender when needed
 		this.lastOutput = '';
 
-		// Store last output height so we know to clear the terminal when the previous output
-		// height is greater than the current terminal height
-		this.lastOutputHeight = 0;
-
 		// This variable is used only in debug mode to store full static output
 		// so that it's rerendered every time, not just new static parts, like in non-debug mode
-		this.fullStaticOutput = '';
 
 		// Emit initial OSC 133 prompt start escape
-		if (!isInCi && options.osc133) {
+		if (!isInCi && isTTY && options.osc133) {
 			options.stdout.write(oscPromptStartRefreshLine);
 		}
 
@@ -172,7 +157,7 @@ export default class Ink {
 
 	resized = () => {
 		this.calculateLayout();
-		this.onRender(true);
+		this.onRender();
 	};
 
 	resolveExitPromise: () => void = () => {};
@@ -181,8 +166,7 @@ export default class Ink {
 
 	calculateLayout = () => {
 		// The 'columns' property can be undefined or 0 when not using a TTY.
-		// In that case we fall back to 80.
-		const terminalWidth = this.options.stdout.columns || 80;
+		const terminalWidth = this.options.stdout.columns || DEFAULT_TERMINAL_WIDTH;
 
 		if (!this.rootNode) {
 			// Yoga is not initialized yet
@@ -198,14 +182,14 @@ export default class Ink {
 		);
 	};
 
-	onRender(didResize = false) {
+	onRender() {
 		// Ask terminal emulators not to redraw the framebuffer
 		// while we're in the middle of a atomic update.  Avoids flicker.
 		try {
 			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateStart);
 			}
-			this.onRenderInternal(didResize);
+			this.onRenderInternal();
 		} finally {
 			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateEnd);
@@ -213,7 +197,7 @@ export default class Ink {
 		}
 	};
 
-	onRenderInternal(didResize: boolean) {
+	onRenderInternal() {
 		if (this.isUnmounted) {
 			return;
 		}
@@ -260,7 +244,7 @@ export default class Ink {
 		// For render() output purposes, we assume we're in command mode,
 		// so whenever we enter prompt mode we leave command mode, and whenever
 		// we leave prompt mode, we re-enter command mode.
-		const {output, outputHeight, staticOutput} = render(
+		const {output, staticOutput} = render(
 			this.rootNode,
 			endOscCommand + startOscPrompt,
 			endOscPrompt + startOscCommand);
@@ -275,65 +259,6 @@ export default class Ink {
 				      staticOutput /* assume ends with \n */ +
 				      startOscPrompt)
 				   : staticOutput;
-
-		if (this.options.debug) {
-			if (hasStaticOutput) {
-				this.fullStaticOutput += wrappedStaticOutput;
-			}
-
-			this.options.stdout.write(this.fullStaticOutput + output);
-			return;
-		}
-
-		if (isInCi) {
-			if (hasStaticOutput) {
-				this.options.stdout.write(wrappedStaticOutput);
-			}
-
-			this.lastOutput = output;
-			this.lastOutputHeight = outputHeight;
-			return;
-		}
-
-		if (hasStaticOutput) {
-			this.fullStaticOutput += wrappedStaticOutput;
-		}
-
-		const writeFullStaticOutput = () => {
-			// fullStaticOutput has embedded prompt-end prompt-start OSC133
-			// sequences; it expects to be printed in the in-prompt state.
-			// Strip any leading prompt-stop off the string when we print
-			// it so that it's appropriate to print in our non-prompt-start
-			// context.  We add an extra newline to match what logOutput does.
-			this.options.stdout.write(
-				endOscPrompt +
-				ansiEscapes.clearTerminal +
-				stripPrefixIfPresent(endOscPrompt, this.fullStaticOutput) +
-				output + '\n');
-		};
-
-		if (
-			outputHeight >= this.options.stdout.rows ||
-			this.lastOutputHeight >= this.options.stdout.rows
-		) {
-			if (this.options.onFlicker) {
-				this.options.onFlicker();
-			}
-			writeFullStaticOutput();
-			this.lastOutput = output;
-			this.lastOutputHeight = outputHeight;
-			// Account for the extra newline
-			this.log.updateLineCount(output + '\n');
-			return;
-		}
-
-		if (didResize) {
-			writeFullStaticOutput();
-			this.lastOutput = output;
-			this.lastOutputHeight = outputHeight;
-			this.log.updateLineCount(output + '\n');
-			return;
-		}
 
 		// To ensure static output is cleanly rendered before main output, clear main output first
 		if (hasStaticOutput) {
@@ -350,7 +275,6 @@ export default class Ink {
 		}
 
 		this.lastOutput = output;
-		this.lastOutputHeight = outputHeight;
 	}
 
 	render(node: ReactNode): void {
@@ -377,7 +301,6 @@ export default class Ink {
 		}
 
 		if (this.options.debug) {
-			this.options.stdout.write(data + this.fullStaticOutput + this.lastOutput);
 			return;
 		}
 
@@ -398,7 +321,6 @@ export default class Ink {
 
 		if (this.options.debug) {
 			this.options.stderr.write(data);
-			this.options.stdout.write(this.fullStaticOutput + this.lastOutput);
 			return;
 		}
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -64,8 +64,7 @@ export default class Output {
 
 	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
-		// Sometimes we get bogus heights like 8.529591648468016e-40
-		this.height = height < 1 ? 0 : height;
+		this.height = height;
 		this.startOscPrompt = startOscPrompt || '';
 		this.endOscPrompt = endOscPrompt || '';
 	}
@@ -105,10 +104,10 @@ export default class Output {
 	}
 
 	get(): {output: string; height: number} {
-		// Initialize output array with a specific set of rows
 		const output: StyledChar[][] = [];
-		// Create local array to track prompt lines for this render
-		const isPromptLine = new Array(this.height).fill(false);
+		// Per-line flag indicating whether any widget on that line
+		// is a prompt.
+		const isPromptLine: boolean[] = [];
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];
@@ -123,6 +122,7 @@ export default class Output {
 			}
 
 			output.push(row);
+			isPromptLine.push(false);
 		}
 
 		const clips: Clip[] = [];

--- a/src/output.ts
+++ b/src/output.ts
@@ -21,6 +21,8 @@ import stringWidth from 'string-width';
 type Options = {
 	width: number;
 	height: number;
+	startOscPrompt?: string;
+	endOscPrompt?: string;
 };
 
 type Operation = WriteOperation | ClipOperation | UnclipOperation;
@@ -52,18 +54,19 @@ type UnclipOperation = {
 export default class Output {
 	width: number;
 	height: number;
+	startOscPrompt: string;
+	endOscPrompt: string;
 
 	private readonly operations: Operation[] = [];
 
 	private charCache: {[line: string]: StyledChar[]} = {};
-	private styledCharsToStringCache: {[serializedStyledChars: string]: string} =
-		{};
+	private styledCharsToStringCache: {[serializedStyledChars: string]: string} = {};
 
-	constructor(options: Options) {
-		const {width, height} = options;
-
+	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
 		this.height = height;
+		this.startOscPrompt = startOscPrompt ?? '!!!!<!!!!';
+		this.endOscPrompt = endOscPrompt ?? '!!!!>!!!!';
 	}
 
 	write(
@@ -101,8 +104,10 @@ export default class Output {
 	}
 
 	get(): {output: string; height: number} {
-		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
+		// Initialize output array with a specific set of rows
 		const output: StyledChar[][] = [];
+		// Create local array to track prompt lines for this render
+		const isPromptLine = new Array(this.height).fill(false);
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];
@@ -192,15 +197,23 @@ export default class Output {
 				let offsetY = 0;
 
 				for (let [index, line] of lines.entries()) {
-					const currentLine = output[y + offsetY];
+					const currentY = y + offsetY;
+					const currentLine = output[currentY];
 
-					// Line can be missing if `text` is taller than height of pre-initialized `this.output`
+					// Line can be missing if `text` is taller than height of pre-initialized output
 					if (!currentLine) {
 						continue;
 					}
 
 					for (const transformer of transformers) {
-						line = transformer(line, index);
+						let result = transformer(line, index);
+                                                if (typeof result == 'string') {
+                                                        result = {line: result};
+                                                }
+
+                                                if (result?.isPrompt) {
+                                                        isPromptLine[currentY] = true;
+                                                }
 					}
 
 					if (!this.charCache.hasOwnProperty(line)) {
@@ -235,22 +248,61 @@ export default class Output {
 			}
 		}
 
-		const generatedOutput = output
-			.map(line => {
-				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
-				const lineWithoutEmptyItems = line.filter(item => item !== undefined);
+		// Group lines by isPrompt to add OSC control sequences at boundaries
+		let currentIsPrompt = false;
+		let result = '';
 
-				const key = JSON.stringify(lineWithoutEmptyItems);
-				if (!this.styledCharsToStringCache.hasOwnProperty(key)) {
-					const result = styledCharsToString(lineWithoutEmptyItems).trimEnd();
-					this.styledCharsToStringCache[key] = result;
-				}
-				return this.styledCharsToStringCache[key];
-			})
-			.join('\n');
+		// Process output lines and add OSC prompt markers at group boundaries
+		for (let i = 0; i < output.length; i++) {
+			const line = output[i]!;
+
+			// Skip empty lines at the end
+			if (i === output.length - 1 && line.every(char => char.value === ' ')) {
+				continue;
+			}
+
+			// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
+			const lineWithoutEmptyItems = line.filter(item => item !== undefined);
+
+			const key = JSON.stringify(lineWithoutEmptyItems);
+			if (!this.styledCharsToStringCache.hasOwnProperty(key)) {
+				const result = styledCharsToString(lineWithoutEmptyItems).trimEnd();
+				this.styledCharsToStringCache[key] = result;
+			}
+
+			const lineText = this.styledCharsToStringCache[key];
+
+			// Use our local tracking array
+			const isPromptLineValue = isPromptLine[i];
+
+			// Add prompt start marker at group boundaries
+			if (!currentIsPrompt && isPromptLineValue) {
+				result += this.startOscPrompt;
+				currentIsPrompt = true;
+			}
+
+			// Add prompt end marker at group boundaries
+			if (currentIsPrompt && !isPromptLineValue) {
+				result += this.endOscPrompt;
+				currentIsPrompt = false;
+			}
+
+			// Add the line
+			result += lineText;
+
+			// Add newline if not the last line
+			if (i < output.length - 1) {
+				result += '\n';
+			}
+		}
+
+		// Ensure prompt is closed at the end if needed
+		if (currentIsPrompt) {
+			result += this.endOscPrompt;
+		}
 
 		return {
-			output: generatedOutput,
+			output: result,
 			height: output.length,
 		};
 	}

--- a/src/output.ts
+++ b/src/output.ts
@@ -215,6 +215,8 @@ export default class Output {
                                                 if (result?.isPrompt) {
                                                         isPromptLine[currentY] = true;
                                                 }
+
+						line = result.line;
 					}
 
 					if (!this.charCache.hasOwnProperty(line)) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -64,9 +64,10 @@ export default class Output {
 
 	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
-		this.height = height;
-		this.startOscPrompt = startOscPrompt ?? '!!!!<!!!!';
-		this.endOscPrompt = endOscPrompt ?? '!!!!>!!!!';
+		// Sometimes we get bogus heights like 8.529591648468016e-40
+		this.height = height < 1 ? 0 : height;
+		this.startOscPrompt = startOscPrompt || '';
+		this.endOscPrompt = endOscPrompt || '';
 	}
 
 	write(

--- a/src/output.ts
+++ b/src/output.ts
@@ -291,18 +291,16 @@ export default class Output {
 			}
 
 			// Add the line
-			result += lineText;
-
-			// Add newline if not the last line
-			if (i < output.length - 1) {
-				result += '\n';
-			}
+			result += lineText + '\n';
 		}
 
 		// Ensure prompt is closed at the end if needed
 		if (currentIsPrompt) {
 			result += this.endOscPrompt;
 		}
+
+		// Always add a trailing newline for consistency between renders
+		result += '\n';
 
 		return {
 			output: result,

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -26,7 +26,13 @@ const applyPaddingToText = (node: DOMElement, text: string): string => {
 	return text;
 };
 
-export type OutputTransformer = (s: string, index: number) => string;
+export type OutputTransformerResult = {
+        line: string,
+        isPrompt?: boolean,
+        [x: string]: any,
+} | string;
+
+export type OutputTransformer = (s: string, index: number) => OutputTransformerResult;
 
 // After nodes are laid out, render each to output object, which later gets rendered to terminal
 const renderNodeToOutput = (

--- a/src/render.ts
+++ b/src/render.ts
@@ -46,6 +46,12 @@ export type RenderOptions = {
 	 * Callback for when Ink re-renders the scrollback.
 	 */
 	onFlicker?: () => unknown;
+
+	/**
+	  * Whether to use OSC133 escape sequences for the terminal
+	  * to mark prompt regions.
+	  */
+	osc133?: boolean;
 };
 
 export type Instance = {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -8,11 +8,15 @@ type Result = {
 	staticOutput: string;
 };
 
-const renderer = (node: DOMElement): Result => {
+const renderer = (node: DOMElement,
+		  startOscPrompt: string,
+		  endOscPrompt: string): Result => {
 	if (node.yogaNode) {
 		const output = new Output({
 			width: node.yogaNode.getComputedWidth(),
 			height: node.yogaNode.getComputedHeight(),
+			startOscPrompt: startOscPrompt,
+			endOscPrompt: endOscPrompt,
 		});
 
 		renderNodeToOutput(node, output, {skipStaticElements: true});
@@ -23,6 +27,8 @@ const renderer = (node: DOMElement): Result => {
 			staticOutput = new Output({
 				width: node.staticNode.yogaNode.getComputedWidth(),
 				height: node.staticNode.yogaNode.getComputedHeight(),
+				startOscPrompt: startOscPrompt,
+				endOscPrompt: endOscPrompt,
 			});
 
 			renderNodeToOutput(node.staticNode, staticOutput, {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,20 +1,29 @@
 import renderNodeToOutput from './render-node-to-output.js';
 import Output from './output.js';
 import {type DOMElement} from './dom.js';
+import ansiEscapes from 'ansi-escapes';
+import { DEFAULT_TERMINAL_HEIGHT } from './constants.js';
 
 type Result = {
 	output: string;
-	outputHeight: number;
 	staticOutput: string;
 };
+
+// Keep track of all static output we've rendered so far
+let staticContentPreviously: string = '';
+// Keep track of the terminal width when we last rendered
+let previousTerminalWidth: number = 0;
 
 const renderer = (node: DOMElement,
 		  startOscPrompt: string,
 		  endOscPrompt: string): Result => {
 	if (node.yogaNode) {
+		const currentTerminalWidth = node.yogaNode.getComputedWidth();
+		const wantedHeight = node.yogaNode.getComputedHeight();
+
 		const output = new Output({
-			width: node.yogaNode.getComputedWidth(),
-			height: node.yogaNode.getComputedHeight(),
+			width: currentTerminalWidth,
+			height: wantedHeight,
 			startOscPrompt: startOscPrompt,
 			endOscPrompt: endOscPrompt,
 		});
@@ -36,20 +45,50 @@ const renderer = (node: DOMElement,
 			});
 		}
 
-		const {output: generatedOutput, height: outputHeight} = output.get();
+		// If our old output is a prefix of our new output, we can just output
+		// the delta.  If it's not, then we have to refresh the screen
+		// and output the whole thing from scratch.
+
+		const {output: generatedOutput, height: _} = output.get();
+		let staticOutputNow = staticOutput
+                                        ? staticOutput.get().output
+					: '';
+		let clearScreen = '';
+
+		const terminalRows = process.stdout.rows || DEFAULT_TERMINAL_HEIGHT;
+
+		// Only do incremental update if:
+		// - width hasn't changed
+		// - content is a prefix of previous content
+
+		// We need the last clause to account for the case when
+		// the non-static content size is taller than the viewport:
+		// we need to render it partially into scrollback in this case,
+		// and the only portable way to edit scrollback is to clear and
+		// refresh it.
+
+		if (currentTerminalWidth === previousTerminalWidth &&
+			wantedHeight < terminalRows &&
+			staticOutputNow.startsWith(staticContentPreviously)) {
+			let delta = staticOutputNow.substring(
+				staticContentPreviously.length);
+			staticContentPreviously += delta;
+			staticOutputNow = delta;
+		} else {
+			// Either width changed or content changed significantly - full redraw
+			clearScreen = ansiEscapes.clearTerminal;
+			staticContentPreviously = staticOutputNow;
+			previousTerminalWidth = currentTerminalWidth;
+		}
 
 		return {
 			output: generatedOutput,
-			outputHeight,
-			// Newline at the end is needed, because static output doesn't have one, so
-			// interactive output will override last line of static output
-			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
+			staticOutput: `${clearScreen}${staticOutputNow}`,
 		};
 	}
 
 	return {
 		output: '',
-		outputHeight: 0,
 		staticOutput: '',
 	};
 };

--- a/src/squash-text-nodes.ts
+++ b/src/squash-text-nodes.ts
@@ -30,11 +30,17 @@ const squashTextNodes = (node: DOMElement): string => {
 
 			// Since these text nodes are being concatenated, `Output` instance won't be able to
 			// apply children transform, so we have to do it manually here for each text node
+			// We can throw away any metadata the transformer returns since we're not using
+			// the result of this function alone for rendering.
 			if (
 				nodeText.length > 0 &&
 				typeof childNode.internal_transform === 'function'
 			) {
-				nodeText = childNode.internal_transform(nodeText, index);
+                                let result = childNode.internal_transform(nodeText, index);
+                                if (typeof result == 'string') {
+                                        result = {line: result};
+                                }
+				nodeText = result.line;
 			}
 		}
 


### PR DESCRIPTION
This change basically reimplements a big chunk of the Ink renderer and output logic.  It gets the Ink core out of the business of caring about screen refreshes and terminal size.  It also gets the index count out of the Static component.  Instead, we make rendering idempotent and move the logic that makes output characters dependent on terminal state into the renderer.  Instead of deleting things incrementally from the static component, we render every static component and rely on logic in the bowels of the renderer to avoid doing full screen refreshes when possible.

The resulting model is simpler, more React-y, and adjusts better to terminal size.

We also by side effect address an unbounded memory use bug in the old renderer: because the old renderer accumulated static content in ink.tsx directly and output it outside React's normal refresh flow, our static content history grew forever.  In long sessions, with lots of /refresh commands, it could reach tens of thousands of lines.

Now, our entire history is encapsulated in the static component, and when we clear or remount that, we forget obsolete data and keep our memory use (and terminal spam) bounded as long as the size of the static is bounded.